### PR TITLE
Define ServerToAgent domain model

### DIFF
--- a/src/main/kotlin/dev/minuk/opampcommander/adapter/secondary/persistence/mongo/agent/AgentMongoAdapter.kt
+++ b/src/main/kotlin/dev/minuk/opampcommander/adapter/secondary/persistence/mongo/agent/AgentMongoAdapter.kt
@@ -1,11 +1,13 @@
 package dev.minuk.opampcommander.adapter.secondary.persistence.mongo.agent
 
+import com.github.f4b6a3.ulid.Ulid
 import dev.minuk.opampcommander.adapter.secondary.persistence.mongo.agent.document.AgentDocument
 import dev.minuk.opampcommander.domain.models.agent.Agent
 import dev.minuk.opampcommander.domain.port.secondary.agent.AgentOperationsPort
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactor.awaitSingle
+import kotlinx.coroutines.reactor.awaitSingleOrNull
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate
 import org.springframework.data.mongodb.core.query.Criteria
 import org.springframework.data.mongodb.core.query.Query
@@ -15,7 +17,7 @@ import org.springframework.stereotype.Component
 class AgentMongoAdapter(
     val reactiveMongoTemplate: ReactiveMongoTemplate,
 ) : AgentOperationsPort {
-    override suspend fun getAgentByInstanceUid(instanceUid: String): Agent {
+    override suspend fun getAgentByInstanceUid(instanceUid: Ulid): Agent? {
         val query = Query.query(Criteria.where("instanceUid").`is`(instanceUid))
         return reactiveMongoTemplate
             .findOne(query, AgentDocument::class.java)
@@ -29,7 +31,7 @@ class AgentMongoAdapter(
                     componentHealth = it.componentHealth,
                     customCapabilities = it.customCapabilities,
                 )
-            }.awaitSingle()
+            }.awaitSingleOrNull()
     }
 
     override suspend fun getAgents(): Flow<Agent> =

--- a/src/main/kotlin/dev/minuk/opampcommander/application/services/OpampService.kt
+++ b/src/main/kotlin/dev/minuk/opampcommander/application/services/OpampService.kt
@@ -37,31 +37,31 @@ class OpampService(
         val agent = getAgentInternalUsecase.getAgent(instanceUid = instanceUid) ?: Agent(instanceUid = instanceUid)
         val updatedAgent =
             agent.report(
-                newAgentDescription =
+                reportedAgentDescription =
                     if (agentToServer.hasAgentDescription()) {
                         agentToServer.agentDescription.toDomain()
                     } else {
                         null
                     },
-                newComponentHealth =
+                reportedComponentHealth =
                     if (agentToServer.hasHealth()) {
                         agentToServer.health.toDomain()
                     } else {
                         null
                     },
-                newEffectiveConfig =
+                reportedEffectiveConfig =
                     if (agentToServer.hasEffectiveConfig()) {
                         agentToServer.effectiveConfig.toDomain()
                     } else {
                         null
                     },
-                newPackageStatuses =
+                reportedPackageStatuses =
                     if (agentToServer.hasPackageStatuses()) {
                         agentToServer.packageStatuses.toDomain()
                     } else {
                         null
                     },
-                newCustomCapabilities =
+                reportedCustomCapabilities =
                     if (agentToServer.hasCustomCapabilities()) {
                         agentToServer.customCapabilities.toDomain()
                     } else {

--- a/src/main/kotlin/dev/minuk/opampcommander/application/services/OpampService.kt
+++ b/src/main/kotlin/dev/minuk/opampcommander/application/services/OpampService.kt
@@ -5,14 +5,31 @@ import com.google.protobuf.ByteString
 import dev.minuk.opampcommander.application.usecases.FetchServerToAgentUsecase
 import dev.minuk.opampcommander.application.usecases.HandleAgentToServerUsecase
 import dev.minuk.opampcommander.domain.models.agent.Agent
+import dev.minuk.opampcommander.domain.models.agent.AgentConfigFile
+import dev.minuk.opampcommander.domain.models.agent.AgentConfigMap
 import dev.minuk.opampcommander.domain.models.agent.AgentDescription
+import dev.minuk.opampcommander.domain.models.agent.AgentIdentification
+import dev.minuk.opampcommander.domain.models.agent.AgentRemoteConfig
 import dev.minuk.opampcommander.domain.models.agent.ComponentHealth
+import dev.minuk.opampcommander.domain.models.agent.ConnectionSettingsOffers
 import dev.minuk.opampcommander.domain.models.agent.CustomCapabilities
 import dev.minuk.opampcommander.domain.models.agent.CustomMessage
 import dev.minuk.opampcommander.domain.models.agent.EffectiveConfig
+import dev.minuk.opampcommander.domain.models.agent.Headers
+import dev.minuk.opampcommander.domain.models.agent.OpAMPConnectionSettings
+import dev.minuk.opampcommander.domain.models.agent.OtherConnectionSettings
+import dev.minuk.opampcommander.domain.models.agent.PackageAvailable
 import dev.minuk.opampcommander.domain.models.agent.PackageStatus
 import dev.minuk.opampcommander.domain.models.agent.PackageStatuses
+import dev.minuk.opampcommander.domain.models.agent.PackagesAvailable
 import dev.minuk.opampcommander.domain.models.agent.RemoteConfigStatus
+import dev.minuk.opampcommander.domain.models.agent.RetryInfo
+import dev.minuk.opampcommander.domain.models.agent.ServerCapabilities
+import dev.minuk.opampcommander.domain.models.agent.ServerErrorResponse
+import dev.minuk.opampcommander.domain.models.agent.ServerToAgentCommand
+import dev.minuk.opampcommander.domain.models.agent.ServerToAgentFlags
+import dev.minuk.opampcommander.domain.models.agent.TLSCertificate
+import dev.minuk.opampcommander.domain.models.agent.TelemetryConnectionSettings
 import dev.minuk.opampcommander.domain.port.primary.agent.GetAgentInternalUsecase
 import dev.minuk.opampcommander.domain.port.primary.agent.UpsertAgentInternalUsecase
 import dev.minuk.opampcommander.util.Logger
@@ -71,11 +88,58 @@ class OpampService(
         upsertAgentInternalUsecase.upsertAgent(updatedAgent)
     }
 
-    override suspend fun fetchServerToAgent(instanceUid: Ulid): Opamp.ServerToAgent? =
-        Opamp.ServerToAgent
-            .newBuilder()
-            .setInstanceUid(ByteString.copyFrom(instanceUid.toBytes()))
-            .build()
+    override suspend fun fetchServerToAgent(instanceUid: Ulid): Opamp.ServerToAgent {
+        val agent =
+            getAgentInternalUsecase.getAgent(instanceUid)
+                ?: return Opamp.ServerToAgent
+                    .newBuilder()
+                    .setInstanceUid(ByteString.copyFrom(instanceUid.toBytes()))
+                    .setErrorResponse(
+                        Opamp.ServerErrorResponse
+                            .newBuilder()
+                            .setErrorMessage("Agent not found")
+                            .build(),
+                    ).build()
+        val serverToAgent = agent.toServerToAgent()
+
+        return serverToAgent.let {
+            val builder =
+                Opamp.ServerToAgent
+                    .newBuilder()
+                    .setInstanceUid(ByteString.copyFrom(it.instanceUid.toBytes()))
+            if (it.errorResponse != null) {
+                builder.setErrorResponse(it.errorResponse.toProto())
+            }
+            if (it.remoteConfig != null) {
+                builder.setRemoteConfig(it.remoteConfig.toProto())
+            }
+            if (it.connectionSettings != null) {
+                builder.setConnectionSettings(it.connectionSettings.toProto())
+            }
+            if (it.packagesAvailable != null) {
+                builder.setPackagesAvailable(it.packagesAvailable.toProto())
+            }
+            if (it.flags != null) {
+                builder.setFlags(it.flags.toProto())
+            }
+            if (it.capabilities != null) {
+                builder.setCapabilities(it.capabilities.toProto())
+            }
+            if (it.agentIdentification != null) {
+                builder.setAgentIdentification(it.agentIdentification.toProto())
+            }
+            if (it.command != null) {
+                builder.setCommand(it.command.toProto())
+            }
+            if (it.customCapabilities != null) {
+                builder.setCustomCapabilities(it.customCapabilities.toProto())
+            }
+            if (it.customMessage != null) {
+                builder.setCustomMessage(it.customMessage.toProto())
+            }
+            builder.build()
+        }
+    }
 
     private fun Opamp.ComponentHealth.toDomain(): ComponentHealth =
         ComponentHealth(
@@ -101,10 +165,15 @@ class OpampService(
 
     private fun Opamp.EffectiveConfig.toDomain(): EffectiveConfig =
         EffectiveConfig(
+            configMap = configMap.toDomain(),
+        )
+
+    private fun Opamp.AgentConfigMap.toDomain(): AgentConfigMap =
+        AgentConfigMap(
             configMap =
-                configMap.configMapMap.mapValues {
-                    EffectiveConfig.AgentConfigMap(
-                        body = it.value.body.toString(),
+                configMapMap.mapValues {
+                    AgentConfigFile(
+                        body = it.value.body.toByteArray(),
                         contentType = it.value.contentType,
                     )
                 },
@@ -149,4 +218,191 @@ class OpampService(
             type = type,
             data = data.toByteArray(),
         )
+
+    private fun ServerErrorResponse.toProto(): Opamp.ServerErrorResponse.Builder {
+        val builder =
+            Opamp.ServerErrorResponse
+                .newBuilder()
+                .setType(Opamp.ServerErrorResponseType.forNumber(type.value))
+                .setErrorMessage(errorMessage)
+        if (retryInfo != null) {
+            builder.setRetryInfo(retryInfo.toProto())
+        }
+
+        return builder
+    }
+
+    private fun RetryInfo.toProto(): Opamp.RetryInfo.Builder {
+        val builder =
+            Opamp.RetryInfo
+                .newBuilder()
+                .setRetryAfterNanoseconds(retryAfter.toNanos())
+        return builder
+    }
+
+    private fun AgentRemoteConfig.toProto(): Opamp.AgentRemoteConfig.Builder {
+        val builder =
+            Opamp.AgentRemoteConfig
+                .newBuilder()
+                .setConfig(config.toProto())
+        return builder
+    }
+
+    private fun AgentConfigMap.toProto(): Opamp.AgentConfigMap.Builder {
+        val builder =
+            Opamp.AgentConfigMap
+                .newBuilder()
+                .putAllConfigMap(
+                    configMap.mapValues {
+                        it.value.toProto()
+                    },
+                )
+        return builder
+    }
+
+    private fun AgentConfigFile.toProto(): Opamp.AgentConfigFile {
+        val builder =
+            Opamp.AgentConfigFile
+                .newBuilder()
+                .setBody(ByteString.copyFrom(body))
+                .setContentType(contentType)
+        return builder.build()
+    }
+
+    private fun ConnectionSettingsOffers.toProto(): Opamp.ConnectionSettingsOffers.Builder {
+        val builder =
+            Opamp.ConnectionSettingsOffers
+                .newBuilder()
+                .setHash(ByteString.copyFrom(hash))
+                .setOpamp(opamp.toProto())
+                .setOwnMetrics(ownMetrics.toProto())
+                .setOwnTraces(ownTraces.toProto())
+                .setOwnLogs(ownLogs.toProto())
+                .putAllOtherConnections(
+                    otherConnections.mapValues {
+                        it.value.toProto()
+                    },
+                )
+        return builder
+    }
+
+    private fun OpAMPConnectionSettings.toProto(): Opamp.OpAMPConnectionSettings.Builder {
+        val builder =
+            Opamp.OpAMPConnectionSettings
+                .newBuilder()
+                .setDestinationEndpoint(destinationEndPoint)
+                .setHeaders(headers.toProto())
+                .setCertificate(certificate.toProto())
+        return builder
+    }
+
+    private fun TelemetryConnectionSettings.toProto(): Opamp.TelemetryConnectionSettings.Builder {
+        val builder =
+            Opamp.TelemetryConnectionSettings
+                .newBuilder()
+                .setDestinationEndpoint(destinationEndPoint)
+                .setHeaders(headers.toProto())
+                .setCertificate(certificate.toProto())
+        return builder
+    }
+
+    private fun OtherConnectionSettings.toProto(): Opamp.OtherConnectionSettings {
+        val builder =
+            Opamp.OtherConnectionSettings
+                .newBuilder()
+                .setDestinationEndpoint(destinationEndPoint)
+                .setHeaders(headers.toProto())
+                .setCertificate(certificate.toProto())
+                .putAllOtherSettings(otherSettings)
+        return builder.build()
+    }
+
+    private fun TLSCertificate.toProto(): Opamp.TLSCertificate.Builder {
+        val builder =
+            Opamp.TLSCertificate
+                .newBuilder()
+                .setCert(ByteString.copyFrom(publicKey))
+                .setPrivateKey(ByteString.copyFrom(privateKey))
+                .setCaCert(ByteString.copyFrom(caPublicKey))
+        return builder
+    }
+
+    private fun Headers.toProto(): Opamp.Headers.Builder {
+        val builder =
+            Opamp.Headers
+                .newBuilder()
+                .addAllHeaders(
+                    headers.map {
+                        Opamp.Header
+                            .newBuilder()
+                            .setKey(it.key)
+                            .setValue(it.value)
+                            .build()
+                    },
+                )
+        return builder
+    }
+
+    private fun PackagesAvailable.toProto(): Opamp.PackagesAvailable.Builder {
+        val builder =
+            Opamp.PackagesAvailable
+                .newBuilder()
+                .putAllPackages(
+                    packages.mapValues {
+                        it.value.toProto()
+                    },
+                ).setAllPackagesHash(ByteString.copyFrom(allPackagesHash))
+        return builder
+    }
+
+    private fun PackageAvailable.toProto(): Opamp.PackageAvailable {
+        val builder =
+            Opamp.PackageAvailable
+                .newBuilder()
+                .setVersion(version)
+                .setHash(ByteString.copyFrom(hash))
+        return builder.build()
+    }
+
+    private fun ServerToAgentFlags.toProto(): Long =
+        flags.fold(0L) { acc, flag ->
+            acc or flag.value.toLong()
+        }
+
+    private fun ServerCapabilities.toProto(): Long =
+        capabilities.fold(0L) { acc, capability ->
+            acc or capability.value.toLong()
+        }
+
+    private fun AgentIdentification.toProto(): Opamp.AgentIdentification.Builder {
+        val builder =
+            Opamp.AgentIdentification
+                .newBuilder()
+                .setNewInstanceUid(ByteString.copyFrom(newInstanceUid.toBytes()))
+        return builder
+    }
+
+    private fun ServerToAgentCommand.toProto(): Opamp.ServerToAgentCommand.Builder {
+        val builder =
+            Opamp.ServerToAgentCommand
+                .newBuilder()
+                .setTypeValue(type.value)
+        return builder
+    }
+
+    private fun CustomCapabilities.toProto(): Opamp.CustomCapabilities.Builder {
+        val builder =
+            Opamp.CustomCapabilities
+                .newBuilder()
+                .addAllCapabilities(capabilities)
+        return builder
+    }
+
+    private fun CustomMessage.toProto(): Opamp.CustomMessage =
+        Opamp.CustomMessage
+            .newBuilder()
+            .setCapability(capability)
+            .setType(type)
+            .setData(ByteString.copyFrom(data))
+            .build()
 }

--- a/src/main/kotlin/dev/minuk/opampcommander/application/services/OpampService.kt
+++ b/src/main/kotlin/dev/minuk/opampcommander/application/services/OpampService.kt
@@ -36,7 +36,7 @@ class OpampService(
 
         val agent = getAgentInternalUsecase.getAgent(instanceUid = instanceUid) ?: Agent(instanceUid = instanceUid)
         val updatedAgent =
-            agent.update(
+            agent.report(
                 newAgentDescription =
                     if (agentToServer.hasAgentDescription()) {
                         agentToServer.agentDescription.toDomain()

--- a/src/main/kotlin/dev/minuk/opampcommander/application/usecases/FetchServerToAgentUsecase.kt
+++ b/src/main/kotlin/dev/minuk/opampcommander/application/usecases/FetchServerToAgentUsecase.kt
@@ -5,7 +5,7 @@ import com.google.protobuf.ByteString
 import opamp.proto.Opamp
 
 interface FetchServerToAgentUsecase {
-    suspend fun fetchServerToAgent(instanceUid: ByteString): Opamp.ServerToAgent? = fetchServerToAgent(Ulid.from(instanceUid.toByteArray()))
+    suspend fun fetchServerToAgent(instanceUid: ByteString): Opamp.ServerToAgent = fetchServerToAgent(Ulid.from(instanceUid.toByteArray()))
 
-    suspend fun fetchServerToAgent(instanceUid: Ulid): Opamp.ServerToAgent?
+    suspend fun fetchServerToAgent(instanceUid: Ulid): Opamp.ServerToAgent
 }

--- a/src/main/kotlin/dev/minuk/opampcommander/domain/models/agent/Agent.kt
+++ b/src/main/kotlin/dev/minuk/opampcommander/domain/models/agent/Agent.kt
@@ -22,20 +22,20 @@ data class Agent(
     )
 
     fun report(
-        newAgentDescription: AgentDescription? = null,
-        newComponentHealth: ComponentHealth? = null,
-        newEffectiveConfig: EffectiveConfig? = null,
-        newPackageStatuses: PackageStatuses? = null,
-        newCustomCapabilities: CustomCapabilities? = null,
+        reportedAgentDescription: AgentDescription? = null,
+        reportedComponentHealth: ComponentHealth? = null,
+        reportedEffectiveConfig: EffectiveConfig? = null,
+        reportedPackageStatuses: PackageStatuses? = null,
+        reportedCustomCapabilities: CustomCapabilities? = null,
     ): Agent =
         Agent(
             instanceUid = this.instanceUid,
-            agentDescription = newAgentDescription ?: this.agentDescription,
-            componentHealth = newComponentHealth ?: this.componentHealth,
-            effectiveConfig = newEffectiveConfig ?: this.effectiveConfig,
+            agentDescription = reportedAgentDescription ?: this.agentDescription,
+            componentHealth = reportedComponentHealth ?: this.componentHealth,
+            effectiveConfig = reportedEffectiveConfig ?: this.effectiveConfig,
             communicationStatus = this.communicationStatus,
-            packageStatuses = newPackageStatuses ?: this.packageStatuses,
-            customCapabilities = newCustomCapabilities ?: this.customCapabilities,
+            packageStatuses = reportedPackageStatuses ?: this.packageStatuses,
+            customCapabilities = reportedCustomCapabilities ?: this.customCapabilities,
         )
 
     val os: Os

--- a/src/main/kotlin/dev/minuk/opampcommander/domain/models/agent/Agent.kt
+++ b/src/main/kotlin/dev/minuk/opampcommander/domain/models/agent/Agent.kt
@@ -21,7 +21,7 @@ data class Agent(
         customCapabilities = CustomCapabilities.empty(),
     )
 
-    fun update(
+    fun report(
         newAgentDescription: AgentDescription? = null,
         newComponentHealth: ComponentHealth? = null,
         newEffectiveConfig: EffectiveConfig? = null,

--- a/src/main/kotlin/dev/minuk/opampcommander/domain/models/agent/Agent.kt
+++ b/src/main/kotlin/dev/minuk/opampcommander/domain/models/agent/Agent.kt
@@ -1,6 +1,8 @@
 package dev.minuk.opampcommander.domain.models.agent
 
 import com.github.f4b6a3.ulid.Ulid
+import opamp.proto.Opamp.DownloadableFile
+import java.time.Duration
 
 data class Agent(
     val instanceUid: Ulid,
@@ -44,4 +46,189 @@ data class Agent(
         get() = agentDescription.service
     val host: Host
         get() = agentDescription.host
+
+    fun applyRemoteConfig(newRemoteConfig: AgentRemoteConfig) {
+        TODO("Not yet implemented")
+    }
+
+    fun toServerToAgent(): ServerToAgent =
+        ServerToAgent(
+            instanceUid = instanceUid,
+            errorResponse = null,
+            remoteConfig = null,
+            connectionSettings = null,
+            packagesAvailable = null,
+            flags = null,
+            capabilities = null,
+            agentIdentification = null,
+            command = null,
+            customCapabilities = null,
+            customMessage = null,
+        )
+}
+
+data class AgentRemoteConfig(
+    val config: AgentConfigMap,
+    val configHash: ByteArray,
+)
+
+data class ServerToAgent(
+    val instanceUid: Ulid,
+    val errorResponse: ServerErrorResponse?,
+    val remoteConfig: AgentRemoteConfig?,
+    val connectionSettings: ConnectionSettingsOffers?,
+    val packagesAvailable: PackagesAvailable?,
+    val flags: ServerToAgentFlags?,
+    val capabilities: ServerCapabilities?,
+    val agentIdentification: AgentIdentification?,
+    val command: ServerToAgentCommand?,
+    val customCapabilities: CustomCapabilities?,
+    val customMessage: CustomMessage?,
+)
+
+data class PackagesAvailable(
+    val packages: Map<String, PackageAvailable>,
+    val allPackagesHash: ByteArray,
+)
+
+data class PackageAvailable(
+    val type: PackageType,
+    val version: String,
+    val file: DownloadableFile,
+    val hash: ByteArray,
+) {
+    enum class PackageType(
+        val value: Int,
+    ) {
+        TopLevelPackage(0),
+        AddonPackage(1),
+        ;
+
+        companion object {
+            fun of(value: Int): PackageType = entries.find { it.value == value }!!
+        }
+    }
+}
+
+data class ServerErrorResponse(
+    val type: Type,
+    val errorMessage: String,
+    val retryInfo: RetryInfo?,
+) {
+    enum class Type(
+        val value: Int,
+    ) {
+        UNKNOWN(0),
+        BAD_REQUEST(1),
+        UNAUTHORIZED(2),
+        ;
+
+        companion object {
+            fun of(value: Int): Type = entries.find { it.value == value }!!
+        }
+    }
+}
+
+data class RetryInfo(
+    val retryAfter: Duration,
+)
+
+data class ConnectionSettingsOffers(
+    val hash: ByteArray,
+    val opamp: OpAMPConnectionSettings,
+    val ownMetrics: TelemetryConnectionSettings,
+    val ownTraces: TelemetryConnectionSettings,
+    val ownLogs: TelemetryConnectionSettings,
+    val otherConnections: Map<String, OtherConnectionSettings>,
+)
+
+data class OpAMPConnectionSettings(
+    val destinationEndPoint: String,
+    val headers: Headers,
+    val certificate: TLSCertificate,
+)
+
+data class Headers(
+    val headers: List<Header>,
+)
+
+data class Header(
+    val key: String,
+    val value: String,
+)
+
+data class TLSCertificate(
+    val publicKey: ByteArray,
+    val privateKey: ByteArray,
+    val caPublicKey: ByteArray,
+)
+
+data class TelemetryConnectionSettings(
+    val destinationEndPoint: String,
+    val headers: Headers,
+    val certificate: TLSCertificate,
+)
+
+data class OtherConnectionSettings(
+    val destinationEndPoint: String,
+    val headers: Headers,
+    val certificate: TLSCertificate,
+    val otherSettings: Map<String, String>,
+)
+
+data class ServerToAgentFlags(
+    val flags: Set<Flag>,
+) {
+    enum class Flag(
+        val value: Int,
+    ) {
+        FlagUnspecified(0),
+        ReportFullState(1),
+        ;
+
+        companion object {
+            fun of(value: Int): Flag = entries.find { it.value == value }!!
+        }
+    }
+}
+
+data class ServerCapabilities(
+    val capabilities: Set<Capability>,
+) {
+    enum class Capability(
+        val value: Int,
+    ) {
+        UnspecifiedServerCapability(0),
+        AcceptsStatus(0x00000001),
+        OffersRemoteConfig(0x00000002),
+        AcceptsEffectiveConfig(0x00000004),
+        OffersPackages(0x00000008),
+        AcceptsPackagesStatus(0x00000010),
+        OffersConnectionSettings(0x00000020),
+        AcceptsConnectionSettingsRequest(0x00000040),
+        ;
+
+        companion object {
+            fun of(value: Int): Capability = entries.find { it.value == value }!!
+        }
+    }
+}
+
+data class AgentIdentification(
+    val newInstanceUid: Ulid,
+)
+
+data class ServerToAgentCommand(
+    val type: CommandType,
+) {
+    enum class CommandType(
+        val value: Int,
+    ) {
+        Restart(0),
+        ;
+
+        companion object {
+            fun of(value: Int): CommandType = entries.find { it.value == value }!!
+        }
+    }
 }

--- a/src/main/kotlin/dev/minuk/opampcommander/domain/models/agent/AgentConfigMap.kt
+++ b/src/main/kotlin/dev/minuk/opampcommander/domain/models/agent/AgentConfigMap.kt
@@ -1,0 +1,14 @@
+package dev.minuk.opampcommander.domain.models.agent
+
+data class AgentConfigMap(
+    val configMap: Map<String, AgentConfigFile>,
+) {
+    companion object {
+        fun empty(): AgentConfigMap = AgentConfigMap(mapOf())
+    }
+}
+
+data class AgentConfigFile(
+    val body: ByteArray,
+    val contentType: String,
+)

--- a/src/main/kotlin/dev/minuk/opampcommander/domain/models/agent/EffectiveConfig.kt
+++ b/src/main/kotlin/dev/minuk/opampcommander/domain/models/agent/EffectiveConfig.kt
@@ -1,14 +1,12 @@
 package dev.minuk.opampcommander.domain.models.agent
 
 data class EffectiveConfig(
-    val configMap: Map<String, AgentConfigMap>,
+    val configMap: AgentConfigMap,
 ) {
     companion object {
-        fun empty(): EffectiveConfig = EffectiveConfig(mapOf())
+        fun empty(): EffectiveConfig =
+            EffectiveConfig(
+                configMap = AgentConfigMap.empty(),
+            )
     }
-
-    data class AgentConfigMap(
-        val body: String,
-        val contentType: String,
-    )
 }

--- a/src/main/kotlin/dev/minuk/opampcommander/domain/port/secondary/agent/AgentOperationsPort.kt
+++ b/src/main/kotlin/dev/minuk/opampcommander/domain/port/secondary/agent/AgentOperationsPort.kt
@@ -1,5 +1,6 @@
 package dev.minuk.opampcommander.domain.port.secondary.agent
 
+import com.github.f4b6a3.ulid.Ulid
 import dev.minuk.opampcommander.domain.models.agent.Agent
 import kotlinx.coroutines.flow.Flow
 
@@ -9,7 +10,7 @@ interface AgentOperationsPort :
     SaveAgentOperation
 
 interface GetAgentOperation {
-    suspend fun getAgentByInstanceUid(instanceUid: String): Agent
+    suspend fun getAgentByInstanceUid(instanceUid: Ulid): Agent?
 }
 
 interface GetAgentsOperation {

--- a/src/main/kotlin/dev/minuk/opampcommander/domain/services/AgentService.kt
+++ b/src/main/kotlin/dev/minuk/opampcommander/domain/services/AgentService.kt
@@ -21,7 +21,7 @@ class AgentService(
         val log by Logger()
     }
 
-    override suspend fun getAgent(instanceUid: Ulid): Agent? = null
+    override suspend fun getAgent(instanceUid: Ulid): Agent? = agentOperationsPort.getAgentByInstanceUid(instanceUid)
 
     override suspend fun upsertAgent(agent: Agent): Agent = agentOperationsPort.saveAgent(agent)
 


### PR DESCRIPTION
related #26 

- Define ServerToAgent domain model
- Use `Ulid` as `instanceUid` on all layers
- Define `Agent. toServerToAgent() : ServerToAgent()` method